### PR TITLE
Refactor Header Component

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,29 +1,27 @@
 import styles from "./style.module.css";
 import Image from "next/image";
-import { NavBar } from "@/components/NavBar";
 import { useRouter } from "next/router";
-import { Button } from "@/components/Button";
-import { UserAvatar } from "../UserAvatar";
 
 interface Props {
-  userLoggedIn?: boolean; // Temporary Prop, will be replaced by an API call in the future
+  justify?: "space-between" | "center";
+  children?: React.ReactNode;
 }
 
 export function Header(props: Props) {
-  const { userLoggedIn } = props;
+  const { justify = "space-between", children } = props;
 
   const router = useRouter();
 
-  const login = () => {
-    router.push("/home");
-  };
+  const logoIsClickable = router.asPath !== "/" && router.asPath !== "/home";
 
   const navigateToHome = () => {
-    router.push("/home");
+    if (logoIsClickable) {
+      router.push("/home");
+    }
   };
 
   return (
-    <div className={styles.header}>
+    <div className={styles.header} data-justify={justify}>
       <Image
         src="/logo.svg"
         alt="RentSpace Logo"
@@ -31,22 +29,9 @@ export function Header(props: Props) {
         height={62}
         onClick={navigateToHome}
         className={styles.logo}
+        data-click={logoIsClickable}
       />
-      {userLoggedIn ? (
-        <>
-          <NavBar />
-          <UserAvatar />
-        </>
-      ) : (
-        <div className={styles.ladingPageButtons}>
-          <Button variant="primary" onClick={login} size="small">
-            Login
-          </Button>
-          <Button variant="secondary" size="small">
-            Cadastrar
-          </Button>
-        </div>
-      )}
+      {children}
     </div>
   );
 }

--- a/src/components/Header/style.module.css
+++ b/src/components/Header/style.module.css
@@ -3,12 +3,23 @@
   width: auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin: 1rem 2rem;
 }
 
-.logo:hover {
+.header[data-justify="space-between"] {
+  justify-content: space-between;
+}
+
+.header[data-justify="center"] {
+  justify-content: center;
+}
+
+.logo:hover[data-click="true"] {
   cursor: pointer;
+}
+
+.logo:hover[data-click="false"] {
+  cursor: default;
 }
 
 .ladingPageButtons {

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -1,17 +1,14 @@
-import { Header } from "../Header";
 import styles from "./style.module.css";
 
 interface Props {
-  userIsLoggedIn: boolean;
   children?: React.ReactNode;
 }
 
 export function Page(props: Props) {
-  const { userIsLoggedIn, children } = props;
+  const { children } = props;
 
   return (
     <>
-      <Header userLoggedIn={userIsLoggedIn} />
       <div className={styles.pageContent}>{children}</div>
     </>
   );

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,16 @@
+import { Header } from "@/components/Header";
+import { NavBar } from "@/components/NavBar";
 import { Page } from "@/components/Page";
+import { UserAvatar } from "@/components/UserAvatar";
 
 export default function Home() {
-  return <Page userIsLoggedIn={true}></Page>;
+  return (
+    <>
+      <Header>
+        <NavBar />
+        <UserAvatar />
+      </Header>
+      <Page></Page>
+    </>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,54 +7,74 @@ import { IconArrowRight } from "@/components/Icons/IconArrowRight";
 import { Text } from "@/components/Text";
 import { Page } from "@/components/Page";
 import { Footer } from "@/components/Footer";
+import { Header } from "@/components/Header";
+import { useRouter } from "next/router";
 
 export default function LandingPage() {
+  const router = useRouter();
+
+  const login = () => {
+    router.push("/home");
+  };
+
   return (
-    <Page userIsLoggedIn={false}>
-      <div className={styles.home}>
-        <section className={styles.homeInformations}>
-          <h1 className={styles.homeTitle}>
-            Encontre o lugar perfeito para a sua próxima
-            <span> comemoração.</span>
-          </h1>
-
-          <span className={styles.appDescription}>
-            Reserve um espaço, contrate um serviço, se preocupe com a diversão
-            da sua festa, simplifique a dor de cabeça da organização conosco.
-          </span>
-
-          <div className={styles.appFunctionalities}>
-            <span>
-              <IconArrowRight />
-              <p>Encontre o espaço perfeito.</p>
-            </span>
-            <span>
-              <IconArrowRight />
-              <p>Contrate os melhores serviços.</p>
-            </span>
-            <span>
-              <IconArrowRight />
-              <p>Aproveite 100% da sua festa.</p>
-            </span>
-          </div>
-
-          <div>
-            <Button variant="primary" size="large">
-              Planejar agora
-            </Button>
-          </div>
-        </section>
-
-        <div className={styles.homeImageCont}>
-          <div className={styles.blurEffect} />
-          <Image src={HomeImg} alt="Home image" className={styles.homeImg} />
+    <>
+      <Header>
+        <div className={styles.login}>
+          <Button variant="primary" onClick={login} size="small">
+            Login
+          </Button>
+          <Button variant="secondary" size="small">
+            Cadastrar
+          </Button>
         </div>
-      </div>
+      </Header>
+      <Page>
+        <div className={styles.home}>
+          <section className={styles.homeInformations}>
+            <h1 className={styles.homeTitle}>
+              Encontre o lugar perfeito para a sua próxima
+              <span> comemoração.</span>
+            </h1>
+
+            <span className={styles.appDescription}>
+              Reserve um espaço, contrate um serviço, se preocupe com a diversão
+              da sua festa, simplifique a dor de cabeça da organização conosco.
+            </span>
+
+            <div className={styles.appFunctionalities}>
+              <span>
+                <IconArrowRight />
+                <p>Encontre o espaço perfeito.</p>
+              </span>
+              <span>
+                <IconArrowRight />
+                <p>Contrate os melhores serviços.</p>
+              </span>
+              <span>
+                <IconArrowRight />
+                <p>Aproveite 100% da sua festa.</p>
+              </span>
+            </div>
+
+            <div>
+              <Button variant="primary" size="large">
+                Planejar agora
+              </Button>
+            </div>
+          </section>
+
+          <div className={styles.homeImageCont}>
+            <div className={styles.blurEffect} />
+            <Image src={HomeImg} alt="Home image" className={styles.homeImg} />
+          </div>
+        </div>
+      </Page>
       <Footer>
         <Text variant="section" tone="secondary">
           Contato &#x2022; Termos de uso
         </Text>
       </Footer>
-    </Page>
+    </>
   );
 }

--- a/src/pages/services/index.tsx
+++ b/src/pages/services/index.tsx
@@ -1,5 +1,16 @@
+import { Header } from "@/components/Header";
+import { NavBar } from "@/components/NavBar";
 import { Page } from "@/components/Page";
+import { UserAvatar } from "@/components/UserAvatar";
 
 export default function Services() {
-  return <Page userIsLoggedIn={true}></Page>;
+  return (
+    <>
+      <Header>
+        <NavBar />
+        <UserAvatar />
+      </Header>
+      <Page></Page>
+    </>
+  );
 }

--- a/src/pages/space/new/index.tsx
+++ b/src/pages/space/new/index.tsx
@@ -1,0 +1,11 @@
+import { Header } from "@/components/Header";
+import { Page } from "@/components/Page";
+
+export default function SpaceNew() {
+  return (
+    <>
+      <Header justify="center" />
+      <Page></Page>
+    </>
+  );
+}

--- a/src/pages/spaces/index.tsx
+++ b/src/pages/spaces/index.tsx
@@ -1,5 +1,16 @@
+import { Header } from "@/components/Header";
+import { NavBar } from "@/components/NavBar";
 import { Page } from "@/components/Page";
+import { UserAvatar } from "@/components/UserAvatar";
 
 export default function Spaces() {
-  return <Page userIsLoggedIn={true}></Page>;
+  return (
+    <>
+      <Header>
+        <NavBar />
+        <UserAvatar />
+      </Header>
+      <Page></Page>
+    </>
+  );
 }

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -55,3 +55,8 @@
   height: 100%;
   position: absolute;
 }
+
+.login {
+  display: flex;
+  column-gap: 1.75rem;
+}


### PR DESCRIPTION
Eu refatorei o componente Header para deixar ele mais flexível e fácil de montar, uma vez que ele muda muito de uma tela para outra. Assim você pode escolher se quer colocar a barra de navegação, o avatar de usuário ou os botões de login passando como `children` pro componente. Além disso, o Header agora tem uma prop opcional que permite escolher o alinhamento, caso a logo precise ficar centralizada. Dessa forma, conseguiremos facilmente construir os headers de todas as telas.

Agora a estrutura de cada página será a seguinte:

```jsx
<Header>
    ...
<Header/>
<Page>
    ...
</Page>
<Footer>
    ...
</Footer>
```